### PR TITLE
update logout handling

### DIFF
--- a/controllers/users/logoutUser.js
+++ b/controllers/users/logoutUser.js
@@ -1,11 +1,22 @@
 const { User } = require("../../models/");
 
 const logoutUser = async (req, res) => {
+
   const { id } = req.user;
-  
-  await User.findByIdAndUpdate({_id: id }, {
-    accessToken: "",
-  });
+  if (id) {
+    await User.findByIdAndUpdate(
+      {_id: id }, 
+      { accessToken: "", }
+    );
+  } else {
+    const { accessToken } = req.accessToken;
+    if ( accessToken ) {
+      User.findOneAndUpdate(
+        { accessToken }, 
+        { $set: { accessToken: "" } }
+      );
+    }
+  }
   
   res.json({"status": "logged out"});
 };

--- a/middlewares/authLogout.js
+++ b/middlewares/authLogout.js
@@ -1,0 +1,41 @@
+const jwt = require("jsonwebtoken");
+
+const { User } = require("../models");
+const {
+  HttpError,
+} = require("../routes/errors/HttpErrors");
+
+const { SECRET_KEY } = process.env;
+
+const authLogout = async (req, res, next) => {
+  const { authorization = "" } = req.headers; // = "" if headers doesn't contain authorization
+  const [bearer, accessToken] =
+    authorization.split(" ");
+  if (bearer !== "Bearer") {
+    next(HttpError(401, "Not authorized"));
+  }
+  try {
+    const { id } = jwt.verify(
+      accessToken,
+      SECRET_KEY
+    );
+    const user = await User.findById(id);
+    if (
+      !user ||
+      !user.accessToken ||
+      user.accessToken !== accessToken
+    ) {
+      next(HttpError(401, "Not authorized"));
+    }
+    req.user = user; // writting user data to req to send it futher
+    next();
+  } catch (error) {
+    if (error.message === "jwt expired") {
+      req.accessToken = accessToken;
+      next()
+    }
+    else next(HttpError(401, error.message));
+  }
+};
+
+module.exports = authLogout;

--- a/middlewares/index.js
+++ b/middlewares/index.js
@@ -1,10 +1,12 @@
 const validateBody = require("./validateBody");
 const auth = require("./auth");
+const authLogout = require("./authLogout");
 const upload = require('./uploadCloud');
 
 
 module.exports = {
   validateBody,
   auth,
+  authLogout,
   upload,
 };

--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -8,6 +8,7 @@ const {
 const {
   validateBody,
   auth,
+  authLogout,
   upload
 } = require("../../middlewares");
 
@@ -29,7 +30,7 @@ router.post(
 
 router.get("/user-data/:uid", auth, ctrl.getUserData);
 
-router.post("/logout", auth, ctrl.logoutUser);
+router.post("/logout", authLogout, ctrl.logoutUser);
 
 router.patch('/user-data', 
   auth, 


### PR DESCRIPTION
Доробляємо логіку логауту:
за сторою схемою юзер з "протухшим" токеном залишався "запертим" на сайті бо auth middleware не пропускала юзера з невалідним токеном в контролер разлогіну
Зараз відбувається перевірка що токен є але він протух - тоді також можлив разлогін і видалення токену з бази